### PR TITLE
Pinokio 1.0 Support + Minor addition

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -84,7 +84,11 @@ module.exports = async kernel =>
             fullscreen: true,
             mode: 'Webcam'
           }
-        },
+        }
+      ];
+    }
+    menu = menu.concat(
+      [
         {
           icon: 'fa-solid fa-rotate',
           text: 'Update',
@@ -94,30 +98,28 @@ module.exports = async kernel =>
             run: true,
             fullscreen: true
           }
+        },
+        {
+          icon: 'fa-solid fa-plug',
+          text: 'Install',
+          href: 'install.js',
+          params:
+          {
+            run: true,
+            fullscreen: true
+          }
+        },
+        {
+          icon: 'fa-solid fa-plug',
+          text: 'Factory Reset',
+          href: 'reset.js',
+          params:
+          {
+            run: true,
+            fullscreen: true
+          }
         }
-      ];
-    }
-    menu.push(
-			{
-				icon: 'fa-solid fa-plug',
-				text: 'Install',
-				href: 'install.js',
-				params:
-				{
-					run: true,
-					fullscreen: true
-				}
-			},
-			{
-				icon: 'fa-solid fa-plug',
-				text: 'Factory Reset',
-				href: 'reset.js',
-				params:
-				{
-					run: true,
-					fullscreen: true
-				}
-			}
+      ]
     )
 	}
 	else

--- a/menu.js
+++ b/menu.js
@@ -48,56 +48,59 @@ module.exports = async kernel =>
         ];
       }
     }
-		menu =
-		[
-			{
-				icon: 'fa-solid fa-power-off',
-				text: 'Launch default',
-				href: 'start.js',
-				params:
-				{
-					run: true,
-					fullscreen: true,
-					mode: 'Default'
-				}
-			},
-			{
-				icon: 'fa-solid fa-gauge',
-				text: 'Launch benchmark',
-				href: 'start.js',
-				params:
-				{
-					run: true,
-					fullscreen: true,
-					mode: 'Benchmark'
-				}
-			},
-			{
-				icon: 'fa-solid fa-camera',
-				text: 'Launch webcam',
-				href: 'start.js',
-				params:
-				{
-					run: true,
-					fullscreen: true,
-					mode: 'Webcam'
-				}
-			},
-			{
-				icon: 'fa-solid fa-rotate',
-				text: 'Update',
-				href: 'update.js',
-				params:
-				{
-					run: true,
-					fullscreen: true
-				}
-			}
-		];
+    else
+    {
+      menu =
+      [
+        {
+          icon: 'fa-solid fa-power-off',
+          text: 'Launch default',
+          href: 'start.js',
+          params:
+          {
+            run: true,
+            fullscreen: true,
+            mode: 'Default'
+          }
+        },
+        {
+          icon: 'fa-solid fa-gauge',
+          text: 'Launch benchmark',
+          href: 'start.js',
+          params:
+          {
+            run: true,
+            fullscreen: true,
+            mode: 'Benchmark'
+          }
+        },
+        {
+          icon: 'fa-solid fa-camera',
+          text: 'Launch webcam',
+          href: 'start.js',
+          params:
+          {
+            run: true,
+            fullscreen: true,
+            mode: 'Webcam'
+          }
+        },
+        {
+          icon: 'fa-solid fa-rotate',
+          text: 'Update',
+          href: 'update.js',
+          params:
+          {
+            run: true,
+            fullscreen: true
+          }
+        }
+      ];
+    }
     menu.push(
 			{
 				icon: 'fa-solid fa-plug',
-				text: 'Reinstall',
+				text: 'Install',
 				href: 'install.js',
 				params:
 				{

--- a/menu.js
+++ b/menu.js
@@ -110,7 +110,7 @@ module.exports = async kernel =>
           }
         },
         {
-          icon: 'fa-solid fa-plug',
+          icon: 'fa-regular fa-circle-mark',
           text: 'Factory Reset',
           href: 'reset.js',
           params:

--- a/menu.js
+++ b/menu.js
@@ -94,6 +94,28 @@ module.exports = async kernel =>
 				}
 			}
 		];
+    menu.push(
+			{
+				icon: 'fa-solid fa-plug',
+				text: 'Reinstall',
+				href: 'install.js',
+				params:
+				{
+					run: true,
+					fullscreen: true
+				}
+			},
+			{
+				icon: 'fa-solid fa-plug',
+				text: 'Factory Reset",
+				href: 'reset.js',
+				params:
+				{
+					run: true,
+					fullscreen: true
+				}
+			}
+    )
 	}
 	else
 	{

--- a/menu.js
+++ b/menu.js
@@ -9,36 +9,48 @@ module.exports = async kernel =>
 	{
 		if (kernel.running(__dirname, 'start.js'))
 		{
-			const session = await kernel.require(__dirname, 'session.json');
-
-			menu =
-			[
-				{
-					icon: 'fa-solid fa-spin fa-circle-notch',
-					text: 'Running ' + session.mode
-				},
-				{
-					icon: 'fa-solid fa-desktop',
-					text: 'Server',
-					href: 'start.js',
-					params:
-					{
-						fullscreen: true
-					}
-				}
-			];
-			if (session && session.url)
-			{
-				menu.push(
-				{
-					icon: 'fa-solid fa-rocket',
-					text: 'Open session',
-					href: session.url,
-					target: '_blank'
-				});
-			}
-			return menu;
-		}
+      const memory = kernel.memory.local[path.resolve(__dirname, "start.json")]
+      if (memory && memory.url && memory.mode)
+      {
+        menu =
+        [
+          {
+            icon: 'fa-solid fa-spin fa-circle-notch',
+            text: 'Running ' + memory.mode
+          },
+          {
+            icon: 'fa-solid fa-desktop',
+            text: 'Server',
+            href: 'start.js',
+            params:
+            {
+              fullscreen: true
+            }
+          },
+          {
+            icon: 'fa-solid fa-rocket',
+            text: 'Open session',
+            href: memory.url,
+            target: '_blank'
+          }
+        ];
+      }
+      else
+      {
+        menu =
+        [
+          {
+            icon: 'fa-solid fa-desktop',
+            text: 'Server',
+            href: 'start.js',
+            params:
+            {
+              fullscreen: true
+            }
+          }
+        ];
+      }
+    }
 		menu =
 		[
 			{

--- a/menu.js
+++ b/menu.js
@@ -107,7 +107,7 @@ module.exports = async kernel =>
 			},
 			{
 				icon: 'fa-solid fa-plug',
-				text: 'Factory Reset",
+				text: 'Factory Reset',
 				href: 'reset.js',
 				params:
 				{

--- a/menu.js
+++ b/menu.js
@@ -10,7 +10,7 @@ module.exports = async kernel =>
 	{
 		if (kernel.running(__dirname, 'start.js'))
 		{
-      const memory = kernel.memory.local[path.resolve(__dirname, "start.json")]
+      const memory = kernel.memory.local[path.resolve(__dirname, "start.js")]
       if (memory && memory.url && memory.mode)
       {
         menu =

--- a/menu.js
+++ b/menu.js
@@ -110,7 +110,7 @@ module.exports = async kernel =>
           }
         },
         {
-          icon: 'fa-regular fa-circle-mark',
+          icon: 'fa-regular fa-circle-xmark',
           text: 'Factory Reset',
           href: 'reset.js',
           params:

--- a/menu.js
+++ b/menu.js
@@ -1,3 +1,4 @@
+const path = require('path')
 module.exports = async kernel =>
 {
 	const hasEnv = await kernel.exists(__dirname, 'facefusion', 'env');

--- a/menu.js
+++ b/menu.js
@@ -16,12 +16,8 @@ module.exports = async kernel =>
         menu =
         [
           {
-            icon: 'fa-solid fa-spin fa-circle-notch',
-            text: 'Running ' + memory.mode
-          },
-          {
             icon: 'fa-solid fa-desktop',
-            text: 'Server',
+            text: 'Server (' + memory.mode + ')',
             href: 'start.js',
             params:
             {

--- a/menu.js
+++ b/menu.js
@@ -16,6 +16,12 @@ module.exports = async kernel =>
         menu =
         [
           {
+            icon: 'fa-solid fa-rocket',
+            text: 'Open session',
+            href: memory.url,
+            target: '_blank'
+          },
+          {
             icon: 'fa-solid fa-desktop',
             text: 'Server (' + memory.mode + ')',
             href: 'start.js',
@@ -23,12 +29,6 @@ module.exports = async kernel =>
             {
               fullscreen: true
             }
-          },
-          {
-            icon: 'fa-solid fa-rocket',
-            text: 'Open session',
-            href: memory.url,
-            target: '_blank'
           }
         ];
       }

--- a/reset.js
+++ b/reset.js
@@ -1,0 +1,8 @@
+{
+  "run": [{
+    "method": "fs.rm",
+    "params": {
+      "path": "facefusion"
+    }
+  }]
+}

--- a/start.js
+++ b/start.js
@@ -38,7 +38,6 @@ module.exports = () =>
 				method: 'local.set',
 				params:
 				{
-          mode: '{{local.mode}}',
           url: '{{input.stdout.match(/(http:\\S+)/gi)[0]}}'
 				}
 			},

--- a/start.js
+++ b/start.js
@@ -35,21 +35,18 @@ module.exports = () =>
 				}
 			},
 			{
-				method: 'self.set',
+				method: 'local.set',
 				params:
 				{
-					'session.json':
-					{
-						mode: '{{local.mode}}',
-						url: '{{input.stdout.match(/(http:\\S+)/gi)[0]}}'
-					}
+          mode: '{{local.mode}}',
+          url: '{{input.stdout.match(/(http:\\S+)/gi)[0]}}'
 				}
 			},
 			{
 				method: 'browser.open',
 				params:
 				{
-					uri: '{{self.session.url}}',
+					uri: '{{local.url}}',
 					target: '_blank'
 				}
 			}


### PR DESCRIPTION
# 1. Factory reset

Added Factory Reset (reset.json): In case something goes wrong with the install, you can click the "Factory Reset" button to reset the entire facefusion repository (and try reinstall)

# 2. Local variables instead of session

Previously the script used `session.json` to determine the current state of the app.

But found a better way to access the script state without writing to files. We can simply access the local memory directly:

```
// The following code returns the local variables object for the `start.js` script
const memory = kernel.memory.local[path.resolve(__dirname, "start.js")]
```

This means no longer need to write to `session.json` files.

Optimized for Pinokio@1.0.6: https://github.com/cocktailpeanutlabs/p2/releases/tag/1.0.6 and works on older versions too.